### PR TITLE
enhance(homepage): add TLF TradeMark Information

### DIFF
--- a/src/components/HomepageSandbox/index.js
+++ b/src/components/HomepageSandbox/index.js
@@ -15,6 +15,9 @@ export default function HomepageSandbox() {
         <Link to="https://www.cncf.io/projects/kubearmor/">
           <img className={styles.logo} src={sandboxImage} alt="logo" />
         </Link>
+        <h4 className={styles.sandboxText}>
+          The Linux Foundation® (TLF) has registered trademarks and uses trademarks. For a list of TLF trademarks, see <Link to="https://www.linuxfoundation.org/trademark-usage/">Trademark Usage</Link>.
+        </h4>
       </div>
     </section>
   );

--- a/src/components/HomepageSandbox/index.js
+++ b/src/components/HomepageSandbox/index.js
@@ -15,7 +15,7 @@ export default function HomepageSandbox() {
         <Link to="https://www.cncf.io/projects/kubearmor/">
           <img className={styles.logo} src={sandboxImage} alt="logo" />
         </Link>
-        <h4 className={styles.sandboxText}>
+        <h4 className={styles.sandboxText} style={{ fontSize: "1rem" }}>
           The Linux Foundation® (TLF) has registered trademarks and uses trademarks. For a list of TLF trademarks, see <Link to="https://www.linuxfoundation.org/trademark-usage/">Trademark Usage</Link>.
         </h4>
       </div>


### PR DESCRIPTION
We need Linux Foundation TradeMark declaration on our website to comply with https://docs.linuxfoundation.org/lfx/insights/v3-beta-version-current/project-overview-page/best-practice-score/checks/legal-checks#trademark-disclaimer